### PR TITLE
Fixed contributing link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 Code for [wabbajack.org](https://www.wabbajack.org), website for [Wabbajack](https://www.github.com/wabbajack-tools/wabbajack).
 
-See [Contributing](Contributing.md) on how to contribute to this repo.
+See [Contributing](CONTRIBUTING.md) on how to contribute to this repo.


### PR DESCRIPTION
Apparently github is case sensitive?
Noticed the link was broken when looking at the page.