### PR TITLE
Add a "Show Game Files" toggle to the manifest viewer (default hidden)

### DIFF
--- a/src/components/ArchiveTable.tsx
+++ b/src/components/ArchiveTable.tsx
@@ -30,17 +30,22 @@ interface IArchiveTableProps {
 
 const ArchiveTable: React.FC<IArchiveTableProps> = (props) => {
   const store = useLocalStore(() => {
-    const archives = filterArchives(props.archives, false);
+    const archives = filterArchives(props.archives, false, false);
     return {
       showNSFW: false,
       showImages: false,
       renderMetaNames: true,
       archives: archives,
+      showGameFiles: false,
     };
   });
 
   const updateArchives = () => {
-    store.archives = filterArchives(props.archives, store.showNSFW);
+    store.archives = filterArchives(
+      props.archives,
+      store.showNSFW,
+      store.showGameFiles
+    );
   };
 
   const toggleNSFW = useObserver(() => {
@@ -91,6 +96,22 @@ const ArchiveTable: React.FC<IArchiveTableProps> = (props) => {
     />
   );
 
+  const toggleGameFiles = (
+    <FormControlLabel
+      control={
+        <Checkbox
+          name="toggleGameFiles"
+          checked={store.showGameFiles}
+          onChange={() => {
+            store.showGameFiles = !store.showGameFiles;
+            updateArchives();
+          }}
+        />
+      }
+      label="Show Game Files"
+    />
+  );
+
   return useObserver(() => {
     return (
       <React.Fragment>
@@ -101,7 +122,7 @@ const ArchiveTable: React.FC<IArchiveTableProps> = (props) => {
             sorting: true,
             headerStyle: { backgroundColor: '#242424' },
             pageSize: 10,
-            pageSizeOptions: [10,50,100,250,500,1000],
+            pageSizeOptions: [10, 50, 100, 250, 500, 1000],
           }}
           components={{
             Toolbar: (props) => (
@@ -122,6 +143,12 @@ const ArchiveTable: React.FC<IArchiveTableProps> = (props) => {
                       >
                         <Grid item>{toggleImages}</Grid>
                       </Tooltip>*/}
+                      <Tooltip
+                        title="This will toggle the showcase of game files."
+                        placement="top"
+                      >
+                        <Grid item>{toggleGameFiles}</Grid>
+                      </Tooltip>
                       <Tooltip
                         title="This will toggle the use of meta names instead of the archive file name."
                         placement="top"

--- a/src/components/ModlistArchiveTable.tsx
+++ b/src/components/ModlistArchiveTable.tsx
@@ -32,12 +32,12 @@ interface Item {
 }
 
 const ModlistArchiveTable: React.FC<IModlistArchiveTableProps> = (props) => {
-  const updateItems = (showNSFW: boolean) => {
+  const updateItems = (showNSFW: boolean, showGameFiles: boolean) => {
     const items = new Array<Item>();
 
     props.data.forEach((val) => {
       const modlist = val[0];
-      const archives = filterArchives(val[1], showNSFW);
+      const archives = filterArchives(val[1], showNSFW, showGameFiles);
 
       archives.forEach((a) => {
         const prevIndex = items.findIndex((x) => x.hash === a.Hash);
@@ -69,7 +69,7 @@ const ModlistArchiveTable: React.FC<IModlistArchiveTableProps> = (props) => {
         return acc;
       }, new Map<string, IArchive>());
 
-    const items = updateItems(false);
+    const items = updateItems(false, false);
 
     return {
       archiveMap: archiveMap,
@@ -77,6 +77,7 @@ const ModlistArchiveTable: React.FC<IModlistArchiveTableProps> = (props) => {
       items: items,
       showNSFW: false,
       renderMetaNames: true,
+      showGameFiles: false,
     };
   });
 
@@ -142,7 +143,7 @@ const ModlistArchiveTable: React.FC<IModlistArchiveTableProps> = (props) => {
             checked={store.showNSFW}
             onChange={() => {
               store.showNSFW = !store.showNSFW;
-              store.items = updateItems(store.showNSFW);
+              store.items = updateItems(store.showNSFW, store.showGameFiles);
             }}
           />
         }
@@ -160,11 +161,27 @@ const ModlistArchiveTable: React.FC<IModlistArchiveTableProps> = (props) => {
           onChange={() => {
             store.renderMetaNames = !store.renderMetaNames;
             //updateArchives();
-            //updateItems(store.showNSFW);
+            //updateItems(store.showNSFW, store.showGameFiles);
           }}
         />
       }
       label="Render Meta Names"
+    />
+  );
+
+  const toggleGameFiles = (
+    <FormControlLabel
+      control={
+        <Checkbox
+          name="toggleGameFiles"
+          checked={store.showGameFiles}
+          onChange={() => {
+            store.showGameFiles = !store.showGameFiles;
+            store.items = updateItems(store.showNSFW, store.showGameFiles);
+          }}
+        />
+      }
+      label="Show Game Files"
     />
   );
 
@@ -192,6 +209,12 @@ const ModlistArchiveTable: React.FC<IModlistArchiveTableProps> = (props) => {
                         placement="top"
                       >
                         <Grid item>{toggleNSFW}</Grid>
+                      </Tooltip>
+                      <Tooltip
+                        title="This will toggle the showcase of game files."
+                        placement="top"
+                      >
+                        <Grid item>{toggleGameFiles}</Grid>
                       </Tooltip>
                       <Tooltip
                         title="This will toggle the use of meta names instead of the archive file name."

--- a/src/utils/archiveUtils.ts
+++ b/src/utils/archiveUtils.ts
@@ -47,11 +47,17 @@ export function tryGetURL(archive: IArchive): string | undefined {
   return createNexusURL(nexusState.GameName, nexusState.ModID);
 }
 
-export const filterArchives = (archives: IArchive[], showNSFW: boolean) => {
+export const filterArchives = (
+  archives: IArchive[],
+  showNSFW: boolean,
+  showGameFiles: boolean
+) => {
   return archives.filter((a) => {
     //no need to filter if we show everything
-    if (showNSFW) return true;
+    if (showNSFW && showGameFiles) return true;
     if (a.State.$type === 'LoversLabDownloader, Wabbajack.Lib') return showNSFW;
+    if (a.State.$type === 'GameFileSourceDownloader, Wabbajack.Lib')
+      return showGameFiles;
 
     const metaState = tryGetMetaState(a.State);
     if (metaState === undefined) return true;


### PR DESCRIPTION
A few lists are using a "Stock Game" methodology where the vanilla
game is copied into the installation folder under a "Stock Game"
folder.  Depending on the game, this floods the manifest with
tens of thousands of entries that are not really that helpful.

~~**WARNING: CURRENTLY COMPLETELY UNTESTED**~~