### PR TITLE
Update games utilities for DA:O and NMS

### DIFF
--- a/src/utils/games.ts
+++ b/src/utils/games.ts
@@ -42,6 +42,12 @@ export const getGameName = (game: Game) => {
     case 'witcher3':
       gameName = 'Witcher 3';
       break;
+    case 'dragonageorigins':
+      gameName = 'Dragon Age: Origins';
+      break;
+    case 'nomanssky':
+      gameName = "No Man's Sky";
+      break;
     default:
       gameName = 'UNKNOWN';
       break;
@@ -53,8 +59,11 @@ export const getNexusGameName = (game: string) => {
   let gameName = game.toLowerCase();
   switch (gameName) {
     case 'falloutnewvegas':
-      gameName = "newvegas";
+      gameName = 'newvegas';
+      break;
+    case 'dragonageorigins':
+      gameName = 'dragonage';
       break;
   }
   return gameName;
-}
+};


### PR DESCRIPTION
This replaces UNKNOWN tags with "Dragon Age: Origins" and
"No Man's Sky".  This also adds a redirect from "dragonageorigin"
to "dragonage" to fix DA:O Nexus links.