### PR TITLE
Make buttons at the bottom of the manifest white

### DIFF
--- a/src/assets/jss/theme.js
+++ b/src/assets/jss/theme.js
@@ -111,13 +111,18 @@ const createTheme = (theme) => {
           backgroundColor: '#323232',
         },
       },
+      MuiSelect: {
+        icon: {
+          color: white
+        }
+      },
       MuiIcon: {
         colorDisabled: 'grey',
       },
       MuiIconButton: {
         colorDisabled: 'grey',
         root: {
-          //color: 'white !important',
+          color: 'white',
         },
       },
       MuiSvgIcon: {


### PR DESCRIPTION
The buttons are now actually visible instead of being black on really dark purple!

Doesn't seem to have an unintended effects on other parts of the website.  