### PR TITLE
Fix logic for filtering NSFW mods

### DIFF
--- a/src/utils/archiveUtils.ts
+++ b/src/utils/archiveUtils.ts
@@ -73,7 +73,7 @@ export const filterArchives = (
 
     const metaState = tryGetMetaState(a.State);
     if (metaState === undefined) return true;
-    return !metaState.IsNSFW;
+    return showNSFW || !metaState.IsNSFW;
   });
 };
 


### PR DESCRIPTION
I messed this up when adding the "show game files" filtering.
The two filters should now be correctly independent.