### PR TITLE
Fix modlists.search.all have error at top

### DIFF
--- a/src/pages/modlists/search/index.tsx
+++ b/src/pages/modlists/search/index.tsx
@@ -8,7 +8,7 @@ import ArchiveSearchPage from './ArchiveSearchPage';
 const SearchPage: React.FC = () => {
   return (
     <React.Fragment>
-      <Route name="modlists.search" component={<ModlistSearchPage />} />
+      <Route exact name="modlists.search" component={<ModlistSearchPage />} />
       <Route
         exact
         name="modlists.search.all"


### PR DESCRIPTION
This is because it renders modlists.search as well because `exact` prop was missing

Thanks `Sneaky Pigeon#6794`

Accompanying error screenshot:
![image](https://user-images.githubusercontent.com/31540342/114271008-eaeec380-9a41-11eb-85c7-0e77407991ee.png)
