### PR TITLE
Remove modlists.search.single route

### DIFF
--- a/src/pages/modlists/gallery/GalleryCard.tsx
+++ b/src/pages/modlists/gallery/GalleryCard.tsx
@@ -67,7 +67,7 @@ const ModlistGalleryCard: React.FC<IModlistGalleryCardProps> = (props) => {
         </RoutedButton>
         <Grid container alignItems="flex-start" justify="flex-end">
           <RoutedButton
-            routeName="modlists.search.single"
+            routeName="modlists.search"
             routeParams={{ machineURL }}
           >
             Archive Search

--- a/src/pages/modlists/search/ModlistSearchPage.tsx
+++ b/src/pages/modlists/search/ModlistSearchPage.tsx
@@ -12,7 +12,7 @@ import { Typography } from '@material-ui/core';
 import ArchiveTable from '../../../components/ArchiveTable';
 
 const ModlistSearchPage: React.FC = () => {
-  const { machineURL } = useRouteNode('modlists.search.single').route.params;
+  const { machineURL } = useRouteNode('modlists.search').route.params;
   const { detailedStatusStore } = useStores();
 
   const urlError = useObserver(() => {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -13,7 +13,6 @@ type RouteName =
   | 'modlists.status.detailed'
   | 'modlists.search'
   | 'modlists.search.all'
-  | 'modlists.search.single'
   | 'modlists.manifest';
 
 interface IRoute extends Route<Record<string, any>> {
@@ -31,7 +30,6 @@ const routes: IRoute[] = [
   { name: 'modlists.status.detailed', path: '?:machineURL' },
   { name: 'modlists.search', path: '/search?:machineURL' },
   { name: 'modlists.search.all', path: '/all' },
-  { name: 'modlists.search.single', path: '?:machineURL' },
   { name: 'modlists.manifest', path: '/manifest' },
 ];
 


### PR DESCRIPTION
- With the (optional) query param now set in modlists.search, modlists.search.single is now redundant
- modlists.search.single does not work properly anyway because having children route with nothing but param is not actually a valid route especially when having other sibling routes with it (it may cause both routes to render in certain cases)
- This also fixes a current issue where if you attempt access the archive search page for specific modlists directly from gallery, it won't load unless you refresh the page