### PR TITLE
Remove the maxSize on the manifest dropzone

### DIFF
--- a/src/pages/modlists/manifest/index.tsx
+++ b/src/pages/modlists/manifest/index.tsx
@@ -76,7 +76,6 @@ const ManifestPage: React.FC = () => {
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop: onDrop,
-    maxSize: 1000000,
     accept: '.json',
     multiple: false,
   });


### PR DESCRIPTION
Manifest files have started to get larger than 1M so the limit
needed to be increased.  The functionality is completely local
so I figured let's just remove the limit.