### PR TITLE
Use Wabbajack.Networking.WabbajackClientApi for loading modlists and …

### DIFF
--- a/Wabbajack.Web/Pages/DetailedStatus/DetailedStatusPage.razor
+++ b/Wabbajack.Web/Pages/DetailedStatus/DetailedStatusPage.razor
@@ -80,7 +80,7 @@
         {
             if (RepositoryName is null || ModlistName is null) return;
 
-            var res = await StateContainer.LoadModlistStatusReport(MachineUrl, _cts.Token);
+            var res = await StateContainer.LoadData(_cts.Token);
             if (!res)
             {
                 _errorLoadingStatusReport = true;

--- a/Wabbajack.Web/Pages/Gallery/Gallery.razor
+++ b/Wabbajack.Web/Pages/Gallery/Gallery.razor
@@ -20,6 +20,11 @@
             <TriCheckboxComponent @bind-State="GalleryState.NSFWState" id="show-nsfw" class="ml-2 h-5 w-5"/>
         </label>
 
+        <label for="show-unofficial" class="w-full md:w-auto font-semibold text-lg inline-flex items-center mt-1">
+            Show Unofficial Lists:
+            <TriCheckboxComponent @bind-State="GalleryState.ShowUnofficial" id="show-unofficial" class="ml-2 h-5 w-5"/>
+        </label>
+
         <div class="w-full md:w-auto">
             <label for="select-game" class="font-semibold text-lg">Select Game:</label>
             <select @bind="GalleryState.SelectedGame" id="select-game" class="w-full p-2 text-black-900 bg-white rounded-md">
@@ -28,18 +33,6 @@
                 @foreach (var game in AllGames)
                 {
                     <option value="@game">@game</option>
-                }
-            </select>
-        </div>
-
-        <div class="w-full md:w-auto">
-            <label for="select-repository" class="font-semibold text-lg">Select Repository:</label>
-            <select @onchange="ChangeRepository" id="select-repository" class="w-full p-2 text-black-900 bg-white rounded-md">
-                <option value="@GalleryState.FeaturedRepository">@GalleryState.FeaturedRepository</option>
-
-                @foreach (var repositoryName in FilteredRepositories)
-                {
-                    <option value="@repositoryName">@repositoryName</option>
                 }
             </select>
         </div>
@@ -91,16 +84,29 @@
         .Where(x => !x.ForceDown)
         .Where(x =>
         {
-            // filter NSFW
-            return GalleryState.NSFWState switch
-            {
-                // exclude NSFW modlists
-                TriCheckboxComponent.TriCheckboxState.False => !x.NSFW,
-                // include NSFW modlists
-                TriCheckboxComponent.TriCheckboxState.True => true,
-                // only NSFW modlists
-                TriCheckboxComponent.TriCheckboxState.Indeterminate => x.NSFW,
-                _ => throw new ArgumentOutOfRangeException()};
+        // filter NSFW
+                return GalleryState.NSFWState switch
+                {
+        // exclude NSFW modlists
+                    TriCheckboxComponent.TriCheckboxState.False => !x.NSFW,
+        // include NSFW modlists
+                    TriCheckboxComponent.TriCheckboxState.True => true,
+        // only NSFW modlists
+                    TriCheckboxComponent.TriCheckboxState.Indeterminate => x.NSFW,
+                    _ => throw new ArgumentOutOfRangeException()};
+        })
+        .Where(x =>
+        {
+        // filter Unofficial
+                return GalleryState.ShowUnofficial switch
+                {
+        // show official modlists
+                    TriCheckboxComponent.TriCheckboxState.False => x.Official,
+        // include unofficial modlists
+                    TriCheckboxComponent.TriCheckboxState.True => true,
+        // only unofficial modlists
+                    TriCheckboxComponent.TriCheckboxState.Indeterminate => !x.Official,
+                    _ => throw new ArgumentOutOfRangeException()};
         })
         .Where(x =>
         {
@@ -129,17 +135,6 @@
         .Select(x => (x, FilteredModlists.Count(y => y.Tags.Contains(x, StringComparer.OrdinalIgnoreCase))))
         .ToDictionary(x => x.x, x => x.Item2, StringComparer.OrdinalIgnoreCase);
 
-    private List<string> _allRepositories = new();
-    private IEnumerable<string> FilteredRepositories => _allRepositories
-        .Where(x => !IgnoredRepositories.Contains(x, StringComparer.OrdinalIgnoreCase));
-
-    private static readonly List<string> IgnoredRepositories = new()
-    {
-        "wj-featured",
-        "wj-utility",
-        "wj-unlisted"
-    };
-
     private bool _errorLoadingModlists;
 
     protected override async Task OnInitializedAsync()
@@ -149,25 +144,21 @@
             GalleryState.GetValuesFromQueryString();
             GalleryState.UpdateQueryString();
 
-            var res = await StateContainer.LoadRepositoryUrls(_cts.Token);
+            var res = await StateContainer.LoadData(_cts.Token);
             if (!res)
             {
                 _errorLoadingModlists = true;
                 return;
             }
 
-            _allRepositories = StateContainer.RepositoryUrls.Keys
-                .OrderBy(x => x)
-                .ToList();
-
-            res = await StateContainer.LoadFeaturedModlists(_cts.Token);
+            res = await StateContainer.LoadData(_cts.Token);
             if (!res)
             {
                 _errorLoadingModlists = true;
                 return;
             }
 
-            _modlists = StateContainer.GetFeaturedModlists().OrderBy(_ => Guid.NewGuid()).ToList();
+            _modlists = StateContainer.GetAllModlists().OrderBy(_ => Guid.NewGuid()).ToList();
 
             _gamesByName = _modlists
                 .Select(x => x.Game)
@@ -195,35 +186,6 @@
         GalleryState.UpdateQueryString();
     }
 
-    private async Task ChangeRepository(ChangeEventArgs eventArgs)
-    {
-        if (eventArgs.Value is not string newRepository) return;
-        GalleryState.SelectedRepository = newRepository;
-
-        if (newRepository == GalleryState.FeaturedRepository)
-        {
-            _modlists = StateContainer.GetFeaturedModlists().OrderBy(_ => Guid.NewGuid()).ToList();
-            return;
-        }
-
-        var res = await StateContainer.LoadRepository(newRepository, _cts.Token);
-        if (!res)
-        {
-            _errorLoadingModlists = true;
-            return;
-        }
-
-        {
-            if (!StateContainer.TryGetRepository(newRepository, out var modlists))
-            {
-                _errorLoadingModlists = true;
-                return;
-            }
-
-            _modlists = modlists.OrderBy(_ => Guid.NewGuid()).ToList();
-        }
-    }
-
     // DO NOT CHANGE "__builder"
     // ReSharper disable InconsistentNaming
     // ReSharper disable once UnusedParameter.Local
@@ -235,7 +197,7 @@
             : readme;
         var archiveSearchLink = ModlistArchiveSearch.CreateRedirect(modlist.RepositoryName, modlist.Links.MachineURL);
 
-        <img src="@modlist.Links.ImageUri"
+        <img src="@modlist.ValidationSummary.SmallImage"
                 alt="Image of the Modlist @modlist.Title"
                 loading="lazy"
                 crossorigin="anonymous"/>

--- a/Wabbajack.Web/Pages/Gallery/GalleryState.cs
+++ b/Wabbajack.Web/Pages/Gallery/GalleryState.cs
@@ -19,7 +19,6 @@ namespace Wabbajack.Web.Pages.Gallery
         }
 
         public const string All = "All";
-        public const string FeaturedRepository = "Featured";
 
         private TriCheckboxComponent.TriCheckboxState _nsfwState = TriCheckboxComponent.TriCheckboxState.False;
         public TriCheckboxComponent.TriCheckboxState NSFWState
@@ -29,6 +28,18 @@ namespace Wabbajack.Web.Pages.Gallery
             {
                 if (value == _nsfwState) return;
                 _nsfwState = value;
+                UpdateQueryString();
+            }
+        }
+
+        private TriCheckboxComponent.TriCheckboxState _showUnofficial = TriCheckboxComponent.TriCheckboxState.False;
+        public TriCheckboxComponent.TriCheckboxState ShowUnofficial
+        {
+            get => _showUnofficial;
+            set
+            {
+                if (value == _showUnofficial) return;
+                _showUnofficial = value;
                 UpdateQueryString();
             }
         }
@@ -44,19 +55,6 @@ namespace Wabbajack.Web.Pages.Gallery
                 UpdateQueryString();
             }
         }
-
-        private string _selectedRepository = FeaturedRepository;
-        public string SelectedRepository
-        {
-            get => _selectedRepository;
-            set
-            {
-                if (value == _selectedRepository) return;
-                _selectedRepository = value;
-                UpdateQueryString();
-            }
-        }
-
         public List<string> SelectedTags { get; set; } = new();
 
         public void UpdateQueryString()
@@ -71,8 +69,14 @@ namespace Wabbajack.Web.Pages.Gallery
                     TriCheckboxComponent.TriCheckboxState.Indeterminate => "indeterminate",
                     _ => throw new ArgumentOutOfRangeException()
                 } },
+                { "showUnofficial", _nsfwState switch
+                {
+                    TriCheckboxComponent.TriCheckboxState.False => null,
+                    TriCheckboxComponent.TriCheckboxState.True => "true",
+                    TriCheckboxComponent.TriCheckboxState.Indeterminate => "indeterminate",
+                    _ => throw new ArgumentOutOfRangeException()
+                } },
                 { "selectedTags", SelectedTags.Count == 0 ? null : SelectedTags.Aggregate((x,y) => $"{x},{y}") },
-                { "selectedRepository", _selectedRepository == FeaturedRepository ? null : _selectedRepository }
             };
 
             var newUri = _navigationManager.GetUriWithQueryParameters(queryParams);
@@ -85,8 +89,6 @@ namespace Wabbajack.Web.Pages.Gallery
 
             if (_selectedGame == All)
                 _selectedGame = query.Get("selectedGame") ?? All;
-            if (_selectedRepository == FeaturedRepository)
-                _selectedRepository = query.Get("selectedRepository") ?? FeaturedRepository;
 
             if (_nsfwState == TriCheckboxComponent.TriCheckboxState.False)
             {

--- a/Wabbajack.Web/Pages/ModlistArchiveSearch/ModlistArchiveSearch.razor
+++ b/Wabbajack.Web/Pages/ModlistArchiveSearch/ModlistArchiveSearch.razor
@@ -107,7 +107,7 @@
         {
             if (RepositoryName is null || ModlistName is null) return;
 
-            var res = await StateContainer.LoadModlistStatusReport(MachineUrl, _cts.Token);
+            var res = await StateContainer.LoadStatusReport(MachineUrl, _cts.Token);
             if (!res)
             {
                 _errorLoadingStatusReport = true;

--- a/Wabbajack.Web/Pages/ModlistInfo/ModlistInfo.razor
+++ b/Wabbajack.Web/Pages/ModlistInfo/ModlistInfo.razor
@@ -66,20 +66,15 @@
         {
             if (RepositoryName is null || ModlistName is null) return;
 
-            var res = await StateContainer.LoadRepository(RepositoryName, _cts.Token);
+            var res = await StateContainer.LoadData(_cts.Token);
             if (!res)
             {
                 _errorLoadingModlists = true;
                 return;
             }
 
-            if (!StateContainer.TryGetRepository(RepositoryName, out var modlists))
-            {
-                _errorLoadingModlists = true;
-                return;
-            }
 
-            var modlist = modlists.FirstOrDefault(x => x.Links.MachineURL.Equals(ModlistName, StringComparison.OrdinalIgnoreCase));
+            var modlist = StateContainer.GetAllModlists().FirstOrDefault(x => x.Links.MachineURL.Equals(ModlistName, StringComparison.OrdinalIgnoreCase));
             if (modlist is null)
             {
                 _errorFindingModlist = true;

--- a/Wabbajack.Web/Pages/StatusDashboard/StatusDashboard.razor
+++ b/Wabbajack.Web/Pages/StatusDashboard/StatusDashboard.razor
@@ -55,7 +55,7 @@
     {
         try
         {
-            var res = await StateContainer.LoadModlistSummaries(_cts.Token);
+            var res = await StateContainer.LoadData(_cts.Token);
             if (!res)
             {
                 _errorLoadingModlists = true;

--- a/Wabbajack.Web/Services/IStateContainer.cs
+++ b/Wabbajack.Web/Services/IStateContainer.cs
@@ -17,28 +17,15 @@ namespace Wabbajack.Web.Services
     {
         bool HasLoadedRepositoryUrls();
         IDictionary<string, string> RepositoryUrls { get; }
-        Task<bool> LoadRepositoryUrls(CancellationToken cancellationToken = default);
-
-        bool TryGetRepository(string repositoryName, [MaybeNullWhen(false)] out List<ModlistMetadata> repository);
         IDictionary<string, List<ModlistMetadata>> Repositories { get; }
-        Task<bool> LoadRepository(string repositoryName, CancellationToken cancellationToken = default);
-
-        bool HasLoadedFeaturedModlistNames();
         IDictionary<string, List<string>> FeaturedModlistNamesByRepository { get; }
-        Task<bool> LoadFeaturedModlistNames(CancellationToken cancellationToken = default);
-
         IEnumerable<ModlistMetadata> GetFeaturedModlists();
-        Task<bool> LoadFeaturedModlists(CancellationToken cancellationToken = default);
-
         IEnumerable<ModlistMetadata> GetAllModlists();
-        Task<bool> LoadAllModlists(CancellationToken cancellationToken = default);
-
         bool HasLoadedModlistSummaries();
         IDictionary<string, ModListSummary> ModlistSummaries { get; }
-        Task<bool> LoadModlistSummaries(CancellationToken cancellationToken = default);
-
         bool TryGetModlistStatusReport(string machineUrl, [MaybeNullWhen(false)] out ValidatedModList statusReport);
         IDictionary<string, ValidatedModList> ModlistStatusReports { get; }
-        Task<bool> LoadModlistStatusReport(string machineUrl, CancellationToken cancellationToken = default);
+        Task<bool> LoadData(CancellationToken ctsToken);
+        Task<bool> LoadStatusReport(string machineUrl, CancellationToken ctsToken);
     }
 }

--- a/Wabbajack.Web/Services/LocalStorageToken.cs
+++ b/Wabbajack.Web/Services/LocalStorageToken.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Blazored.LocalStorage;
+using Microsoft.Extensions.Logging;
+using Wabbajack.DTOs.JsonConverters;
+using Wabbajack.Networking.Http.Interfaces;
+
+namespace Wabbajack.Web.Services;
+
+public class LocalStorageToken<T> : ITokenProvider<T>
+{
+    private readonly ILogger _logger;
+    protected readonly ILocalStorageService _storage;
+    protected readonly string _key;
+    private readonly DTOSerializer _dtos;
+
+    public LocalStorageToken(ILogger logger, ILocalStorageService storage, DTOSerializer dtos, string key)
+    {
+        _logger = logger;
+        _storage = storage;
+        _key = key;
+        _dtos = dtos;
+    }
+
+    public virtual async ValueTask<T> Get()
+    {
+        var data = await _storage.GetItemAsync<string>(_key, CancellationToken.None);
+        return JsonSerializer.Deserialize<T>(data, _dtos.Options);
+    }
+
+    public async ValueTask SetToken(T val)
+    {
+        var json = JsonSerializer.Serialize(val);
+        await _storage.SetItemAsStringAsync(_key, json);
+    }
+
+    public async ValueTask<bool> Delete()
+    {
+        await _storage.RemoveItemAsync(_key);
+        return true;
+    }
+
+    public bool HaveToken()
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Wabbajack.Web/Services/StateContainer.cs
+++ b/Wabbajack.Web/Services/StateContainer.cs
@@ -12,43 +12,25 @@ using Microsoft.Extensions.Logging;
 using Wabbajack.DTOs;
 using Wabbajack.DTOs.JsonConverters;
 using Wabbajack.DTOs.ModListValidation;
+using Wabbajack.Networking.WabbajackClientApi;
 
 namespace Wabbajack.Web.Services
 {
     public class StateContainer : IStateContainer
     {
-        // name of the repository that contain the "official" modlists
-        private const string OfficialRepositoryName = "wj-featured";
-        // url to the repository manifest for the "official" modlists
-        private const string OfficialRepositoryUrl = "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/modlists.json";
-        // url to the list containing every repository
-        private const string RepositoriesUrl = "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/repositories.json";
-        // url to the list of featured modlists outside the "official" repository
-        private const string FeaturedModlistNamesUrl = "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/featured_lists.json";
-        // url to the summary of all modlists from all repositories containing links to the status reports and other status info
-        private const string ModlistsSummaryUrl = "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/reports/modListSummary.json";
-        // base url for all status reports
-        private const string ModlistStatusBaseUrl = "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/";
-
         private readonly ILogger<StateContainer> _logger;
-        private readonly HttpClient _client;
-        private readonly JsonSerializerOptions _jsonSerializerOptions;
 
-        public StateContainer(ILogger<StateContainer> logger, HttpClient client, DTOSerializer dtoSerializer)
+        public StateContainer(ILogger<StateContainer> logger, Client wjClient)
         {
             _logger = logger;
-            _client = client;
-
-            _jsonSerializerOptions = dtoSerializer.Options;
-            _jsonSerializerOptions.ReadCommentHandling = JsonCommentHandling.Skip;
-            _jsonSerializerOptions.AllowTrailingCommas = true;
+            _wjClient = wjClient;
         }
 
         private readonly Dictionary<string, string> _repositoryUrls = new(StringComparer.OrdinalIgnoreCase);
         public IDictionary<string, string> RepositoryUrls => _repositoryUrls;
 
-        private readonly Dictionary<string, List<ModlistMetadata>> _repositories = new(StringComparer.OrdinalIgnoreCase);
-        public IDictionary<string, List<ModlistMetadata>> Repositories => _repositories;
+        public IDictionary<string, List<ModlistMetadata>> Repositories => _repositories.ToDictionary(r => r.Key,
+            r => _modlists.Where(m => m.RepositoryName == r.Key).ToList());
 
         private Dictionary<string, List<string>> _featuredModlistNamesByRepository = new(StringComparer.OrdinalIgnoreCase);
         public IDictionary<string, List<string>> FeaturedModlistNamesByRepository => _featuredModlistNamesByRepository;
@@ -57,239 +39,68 @@ namespace Wabbajack.Web.Services
         public IDictionary<string, ModListSummary> ModlistSummaries => _modlistSummaries;
 
         private readonly Dictionary<string, ValidatedModList> _modlistStatusReports = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Client _wjClient;
+        private ModlistMetadata[] _modlists = Array.Empty<ModlistMetadata>();
+        private IDictionary<string,Uri> _repositories = new Dictionary<string, Uri>();
         public IDictionary<string, ValidatedModList> ModlistStatusReports => _modlistStatusReports;
 
         // we manually add "wj-featured" to the dictionary so here we want to check for > 1
-        public bool HasLoadedRepositoryUrls() => _repositoryUrls.Count > 1;
-        public bool TryGetRepository(string repositoryName, [MaybeNullWhen(false)] out List<ModlistMetadata> repository) => _repositories.TryGetValue(repositoryName, out repository) && repository.Count != 0;
-        public bool HasLoadedFeaturedModlistNames() => _featuredModlistNamesByRepository.Count != 0;
+        public bool HasLoadedRepositoryUrls() => _repositoryUrls.Count > 0;
         public bool HasLoadedModlistSummaries() => _modlistSummaries.Count != 0;
         public bool TryGetModlistStatusReport(string machineUrl, [MaybeNullWhen(false)] out ValidatedModList statusReport) => _modlistStatusReports.TryGetValue(machineUrl, out statusReport);
 
         public IEnumerable<ModlistMetadata> GetFeaturedModlists()
         {
-            if (!HasLoadedFeaturedModlistNames()) yield break;
-            if (!TryGetRepository(OfficialRepositoryName, out var officialModlists)) yield break;
-
-            foreach (var officialModlist in officialModlists)
-            {
-                yield return officialModlist;
-            }
-
-            foreach (var repositoryName in _featuredModlistNamesByRepository.Keys)
-            {
-                if (!TryGetRepository(repositoryName, out var modlists)) yield break;
-
-                var featured = _featuredModlistNamesByRepository[repositoryName];
-                foreach (var modlistName in featured)
-                {
-                    var featuredModlist = modlists.FirstOrDefault(x => x.Links.MachineURL.Equals(modlistName, StringComparison.OrdinalIgnoreCase));
-                    if (featuredModlist is null) yield break;
-                    yield return featuredModlist;
-                }
-            }
+            return _modlists.Where(m => m.Official);
         }
 
         public IEnumerable<ModlistMetadata> GetAllModlists()
         {
-            return _repositories.SelectMany(x => x.Value);
+            return _modlists;
         }
 
-        public async Task<bool> LoadRepositoryUrls(CancellationToken cancellationToken = default)
+        public async Task<bool> LoadData(CancellationToken ctsToken)
         {
-            if (HasLoadedRepositoryUrls()) return true;
-
+            if (_modlists.Length > 0) return true;
             try
             {
-                var res = await _client.GetFromJsonAsync<Dictionary<string, string>>(RepositoriesUrl, _jsonSerializerOptions, cancellationToken);
-                if (res is null || res.Count == 0)
-                {
-                    _logger.LogWarning("Loaded 0 Repositories from {Url}", RepositoriesUrl);
-                    return false;
-                }
+                var modlists = _wjClient.LoadLists();
+                var repositories = _wjClient.LoadRepositories();
+                var summaries = (await _wjClient.GetListStatuses()).ToDictionary(m => m.MachineURL);
 
-                foreach (var (key, value) in res)
+                _modlists = (await modlists).Select(l =>
                 {
-                    _repositoryUrls.TryAdd(key, value);
-                }
-
-                return true;
+                    if (summaries.TryGetValue(l.NamespacedName, out var summary))
+                        l.ValidationSummary = summary;
+                    return l;
+                }).ToArray();
+                _repositories = await repositories;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                _logger.LogError(e, "Exception while loading Repositories from {Url}", RepositoriesUrl);
+                _logger.LogError(ex, "While loading modlist data");
                 return false;
             }
-        }
-
-        public async Task<bool> LoadRepository(string repositoryName, CancellationToken cancellationToken = default)
-        {
-            if (TryGetRepository(repositoryName, out _)) return true;
-
-            if (!HasLoadedRepositoryUrls())
-            {
-                var res = await LoadRepositoryUrls(cancellationToken);
-                if (!res) return false;
-            }
-
-            if (!RepositoryUrls.TryGetValue(repositoryName, out var repositoryUrl))
-            {
-                _logger.LogError("Unknown Repository: \"{RepositoryName}\"", repositoryName);
-                return false;
-            }
-
-            try
-            {
-                var res = await _client.GetFromJsonAsync<List<ModlistMetadata>>(repositoryUrl, _jsonSerializerOptions, cancellationToken);
-                if (res is null || res.Count == 0)
-                {
-                    _logger.LogWarning("Loaded 0 Modlists from Repository \"{RepositoryName}\" at {Url}", repositoryName, repositoryUrl);
-                    return false;
-                }
-
-                foreach (var modlist in res)
-                {
-                    // need to manually set the repository name as it's not saved in JSON
-                    modlist.RepositoryName = repositoryName;
-                }
-
-                _repositories.TryAdd(repositoryName, res);
-                return true;
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "Exception while loading Modlists from Repository \"{RepositoryName}\" at {Url}", repositoryName, repositoryUrl);
-                return false;
-            }
-        }
-
-        public async Task<bool> LoadFeaturedModlistNames(CancellationToken cancellationToken = default)
-        {
-            if (HasLoadedFeaturedModlistNames()) return true;
-
-            try
-            {
-                var res = await _client.GetFromJsonAsync<List<string>>(FeaturedModlistNamesUrl, _jsonSerializerOptions, cancellationToken);
-                if (res is null || res.Count == 0)
-                {
-                    _logger.LogWarning("Loaded 0 featured Modlists from {Url}", FeaturedModlistNamesUrl);
-                    return false;
-                }
-
-                // "{repo}/{modlistName}"
-                _featuredModlistNamesByRepository = res
-                    .Select(x => x.Split('/'))
-                    .Select(x => (repositoryName: x[0], modlistName: x[1]))
-                    .GroupBy(x => x.repositoryName, x => x.modlistName)
-                    .ToDictionary(x => x.Key, x => x.ToList(), StringComparer.OrdinalIgnoreCase);
-
-                return true;
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "Exception while loading featured Modlists from {Url}", FeaturedModlistNamesUrl);
-                return false;
-            }
-        }
-
-        public async Task<bool> LoadFeaturedModlists(CancellationToken cancellationToken = default)
-        {
-            if (!HasLoadedFeaturedModlistNames())
-            {
-                var res = await LoadFeaturedModlistNames(cancellationToken);
-                if (!res) return false;
-            }
-
-            if (!TryGetRepository(OfficialRepositoryName, out _))
-            {
-                _repositoryUrls.TryAdd(OfficialRepositoryName, OfficialRepositoryUrl);
-                var res = await LoadRepository(OfficialRepositoryName, cancellationToken);
-                if (!res) return false;
-            }
-
-            foreach (var repositoryName in _featuredModlistNamesByRepository.Keys)
-            {
-                var res = await LoadRepository(repositoryName, cancellationToken);
-                if (!res) return false;
-            }
-
             return true;
         }
 
-        public async Task<bool> LoadAllModlists(CancellationToken cancellationToken = default)
+        public async Task<bool> LoadStatusReport(string machineUrl, CancellationToken ctsToken)
         {
-            if (!HasLoadedRepositoryUrls())
-            {
-                var res = await LoadRepositoryUrls(cancellationToken);
-                if (!res) return false;
-            }
-
-            foreach (var repositoryName in _repositoryUrls.Keys)
-            {
-                await LoadRepository(repositoryName, cancellationToken);
-            }
-
-            return true;
-        }
-
-        public async Task<bool> LoadModlistSummaries(CancellationToken cancellationToken = default)
-        {
-            if (HasLoadedModlistSummaries()) return true;
+            if (_modlistStatusReports.ContainsKey(machineUrl))
+                return true;
 
             try
             {
-                var res = await _client.GetFromJsonAsync<List<ModListSummary>>(ModlistsSummaryUrl, _jsonSerializerOptions, cancellationToken);
-                if (res is null || res.Count == 0)
-                {
-                    _logger.LogWarning("Loaded 0 Modlist summaries from {Url}", ModlistsSummaryUrl);
-                    return false;
-                }
-
-                _modlistSummaries = res.ToDictionary(x => x.MachineURL, x => x, StringComparer.OrdinalIgnoreCase);
+                var report = await _wjClient.GetDetailedStatus(machineUrl);
+                _modlistStatusReports[machineUrl] = report;
                 return true;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                _logger.LogError(e, "Exception while loading Modlist summaries from {Url}", ModlistsSummaryUrl);
-                return false;
-            }
-        }
-
-        public async Task<bool> LoadModlistStatusReport(string machineUrl, CancellationToken cancellationToken = default)
-        {
-            if (TryGetModlistStatusReport(machineUrl, out _)) return true;
-
-            if (!HasLoadedModlistSummaries())
-            {
-                var res = await LoadModlistSummaries(cancellationToken);
-                if (!res) return false;
-            }
-
-            if (!_modlistSummaries.TryGetValue(machineUrl, out var modListSummary))
-            {
-                _logger.LogError("Unable to find summary of Modlist \"{MachineUrl}\"", machineUrl);
+                _logger.LogError(ex, "While loading Status Report");
                 return false;
             }
 
-            var statusReportUrl = ModlistStatusBaseUrl + modListSummary.Link;
-
-            try
-            {
-                var res = await _client.GetFromJsonAsync<ValidatedModList>(statusReportUrl, _jsonSerializerOptions, cancellationToken);
-                if (res is null)
-                {
-                    _logger.LogWarning("Loaded null status report for Modlist \"{MachineUrl}\" at {Url}", machineUrl, statusReportUrl);
-                    return false;
-                }
-
-                _modlistStatusReports.TryAdd(machineUrl, res);
-                return true;
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "Exception while loading status report for Modlist \"{MachineUrl}\" at {Url}", machineUrl, statusReportUrl);
-                return false;
-            }
         }
     }
 }

--- a/Wabbajack.Web/Services/WabbajackApiStateProvider.cs
+++ b/Wabbajack.Web/Services/WabbajackApiStateProvider.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading.Tasks;
+using Blazored.LocalStorage;
+using Microsoft.Extensions.Logging;
+using Wabbajack.DTOs.JsonConverters;
+using Wabbajack.DTOs.Logins;
+using Wabbajack.Hashing.xxHash64;
+
+namespace Wabbajack.Web.Services;
+
+public class WabbajackApiStateProvider : LocalStorageToken<WabbajackApiState>
+{
+    public WabbajackApiStateProvider(ILogger<WabbajackApiStateProvider> logger, ILocalStorageService storage, DTOSerializer dtos) : base(logger, storage, dtos, "wabbajack-api")
+    {
+
+    }
+
+    public override async ValueTask<WabbajackApiState> Get()
+    {
+        if (await _storage.ContainKeyAsync(_key))
+        {
+            return await base.Get();
+        }
+        else
+        {
+            var random = new Random();
+
+            var bytes = new byte[64];
+            random.NextBytes(bytes);
+            var state = new WabbajackApiState
+            {
+                MetricsKey = bytes.ToHex()
+
+            };
+            await base.SetToken(state);
+            return state;
+        }
+    }
+
+}

--- a/Wabbajack.Web/Shared/ModlistCarousel.razor
+++ b/Wabbajack.Web/Shared/ModlistCarousel.razor
@@ -15,7 +15,7 @@
                 <a href="@ModlistInfo.CreateRedirect(_currentModlist.RepositoryName, _currentModlist.Links.MachineURL)">
                     <img class="w-full aspect-video"
                          loading="eager"
-                         src="@_currentModlist.Links.ImageUri"
+                         src="@_currentModlist.ValidationSummary.LargeImage"
                          alt="Image of Modlist @_currentModlist.Title"/>
                 </a>
 
@@ -57,7 +57,7 @@
     {
         try
         {
-            var res = await StateContainer.LoadFeaturedModlists(_cts.Token);
+            var res = await StateContainer.LoadData(_cts.Token);
             if (!res)
             {
                 _errorLoadingModlists = true;

--- a/Wabbajack.Web/Wabbajack.Web.csproj
+++ b/Wabbajack.Web/Wabbajack.Web.csproj
@@ -17,10 +17,16 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Blazored.LocalStorage" Version="4.3.0-preview.1" />
         <PackageReference Include="Markdig" Version="0.30.2" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.4" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.4" PrivateAssets="all" />
-        <PackageReference Include="Wabbajack.DTOs" Version="3.0.0-beta8" />
+        <PackageReference Include="Wabbajack.DTOs" Version="3.0.0.2" />
+        <PackageReference Include="Wabbajack.Networking.WabbajackClientApi" Version="3.0.0.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="DTOs" />
     </ItemGroup>
 
     <Target Name="RunPostcss" BeforeTargets="Build">


### PR DESCRIPTION
…other such state

Instead of custom logic in the StateContainer. Also uses the new processed images from the ValidateLists command. Now no matter what users do, we'll be using small webp images on the site. Also changes the "repository" dropdown on the page to a single "show unofficial lists" button to more closely match the app.