### PR TITLE
Clear selected tags when a new game is selected

### DIFF
--- a/Wabbajack.Web/Pages/Gallery/GalleryState.cs
+++ b/Wabbajack.Web/Pages/Gallery/GalleryState.cs
@@ -52,6 +52,7 @@ namespace Wabbajack.Web.Pages.Gallery
             {
                 if (value == _selectedGame) return;
                 _selectedGame = value;
+                SelectedTags.Clear();
                 UpdateQueryString();
             }
         }
@@ -76,7 +77,9 @@ namespace Wabbajack.Web.Pages.Gallery
                     TriCheckboxComponent.TriCheckboxState.Indeterminate => "indeterminate",
                     _ => throw new ArgumentOutOfRangeException()
                 } },
-                { "selectedTags", SelectedTags.Count == 0 ? null : SelectedTags.Aggregate((x,y) => $"{x},{y}") },
+                {
+                    "selectedTags", SelectedTags.Count == 0 ? null : SelectedTags.Aggregate((x,y) => $"{x},{y}")
+                },
             };
 
             var newUri = _navigationManager.GetUriWithQueryParameters(queryParams);


### PR DESCRIPTION
Just a quick PR to clear the selected tags when a new game is selected in the gallery, as otherwise it can look like there are no modpacks for a game if, for example, Survival, Roleplay, and Creation Club were selected before changing the selected game to Kerbal Space Program.

Unsure why git thinks it's 114 additions, 111 deletions - all I did was add `SelectedTags.Clear();` after line 54.