### PR TITLE
Fix Gallery & Status Pages -- Fix calls to GetDetailedStatus method in WabbajackClientApi.Client

### DIFF
--- a/Wabbajack.Web/Pages/DetailedStatus/DetailedStatusPage.razor
+++ b/Wabbajack.Web/Pages/DetailedStatus/DetailedStatusPage.razor
@@ -1,4 +1,4 @@
-﻿@page "/status/{repositoryName}/{modlistName}"
+@page "/status/{repositoryName}/{modlistName}"
 @using Wabbajack.Web.Services
 @using Wabbajack.DTOs.ServerResponses
 @using Wabbajack.DTOs.ModListValidation
@@ -81,7 +81,7 @@
         {
             if (RepositoryName is null || ModlistName is null) return;
 
-            var res = await StateContainer.LoadStatusReport(MachineUrl, _cts.Token);
+            var res = await StateContainer.LoadStatusReport(RepositoryName, MachineUrl, _cts.Token);
             if (!res)
             {
                 _errorLoadingStatusReport = true;

--- a/Wabbajack.Web/Pages/ModlistArchiveSearch/ModlistArchiveSearch.razor
+++ b/Wabbajack.Web/Pages/ModlistArchiveSearch/ModlistArchiveSearch.razor
@@ -1,4 +1,4 @@
-﻿@page "/search/{repositoryName}/{modlistName}"
+@page "/search/{repositoryName}/{modlistName}"
 @using Wabbajack.Web.Services
 @using Wabbajack.DTOs.DownloadStates
 @using Wabbajack.DTOs
@@ -107,7 +107,7 @@
         {
             if (RepositoryName is null || ModlistName is null) return;
 
-            var res = await StateContainer.LoadStatusReport(MachineUrl, _cts.Token);
+            var res = await StateContainer.LoadStatusReport(RepositoryName, MachineUrl, _cts.Token);
             if (!res)
             {
                 _errorLoadingStatusReport = true;

--- a/Wabbajack.Web/Services/IStateContainer.cs
+++ b/Wabbajack.Web/Services/IStateContainer.cs
@@ -26,6 +26,6 @@ namespace Wabbajack.Web.Services
         bool TryGetModlistStatusReport(string machineUrl, [MaybeNullWhen(false)] out ValidatedModList statusReport);
         IDictionary<string, ValidatedModList> ModlistStatusReports { get; }
         Task<bool> LoadData(CancellationToken ctsToken);
-        Task<bool> LoadStatusReport(string machineUrl, CancellationToken ctsToken);
+        Task<bool> LoadStatusReport(string repositoryName, string machineUrl, CancellationToken ctsToken);
     }
 }

--- a/Wabbajack.Web/Services/StateContainer.cs
+++ b/Wabbajack.Web/Services/StateContainer.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -84,14 +84,14 @@ namespace Wabbajack.Web.Services
             return true;
         }
 
-        public async Task<bool> LoadStatusReport(string machineUrl, CancellationToken ctsToken)
+        public async Task<bool> LoadStatusReport(string repositoryName, string machineUrl, CancellationToken ctsToken)
         {
             if (_modlistStatusReports.ContainsKey(machineUrl))
                 return true;
 
             try
             {
-                var report = await _wjClient.GetDetailedStatus(machineUrl);
+                var report = await _wjClient.GetDetailedStatus(repositoryName, machineUrl);
                 _modlistStatusReports[machineUrl] = report;
                 return true;
             }


### PR DESCRIPTION
The `Wabbajack.Networking.WabbajackClientApi.Client.GetDetailedStatus` method was changed in [https://github.com/wabbajack-tools/wabbajack/pull/2705](https://github.com/wabbajack-tools/wabbajack/pull/2705) to take a `repository` parameter in addition to `machineURL`.

This updates the method definition and invocations in `Wabbajack.Web` to pass down the `RepositoryName` property to this method.

Without this change, the Gallery and Status pages do not work on the website.